### PR TITLE
Fix a race for the CUDA event between DeviceFree() and DeviceAllocate() in the allocator

### DIFF
--- a/cub/util_allocator.cuh
+++ b/cub/util_allocator.cuh
@@ -585,9 +585,6 @@ struct CachingDeviceAllocator
             }
         }
 
-        // Unlock
-        mutex.Unlock();
-
         // First set to specified device (entrypoint may not be set)
         if (device != entrypoint_device)
         {
@@ -600,7 +597,11 @@ struct CachingDeviceAllocator
             // Insert the ready event in the associated stream (must have current device set properly)
             if (CubDebug(error = cudaEventRecord(search_key.ready_event, search_key.associated_stream))) return error;
         }
-        else
+
+        // Unlock
+        mutex.Unlock();
+
+        if (!recached)
         {
             // Free the allocation from the runtime and cleanup the event.
             if (CubDebug(error = cudaFree(d_ptr))) return error;


### PR DESCRIPTION
I believe there is a race condition on the CUDA event between `DeviceFree()` and `DeviceAllocate()`.

Now the mutex is unlocked after the freed memory block is inserted in the free list (`cached_blocks`), but before the `cudaEventRecord()`. Then there is a short period of time when the memory block is in the free list, and the status of the CUDA event is not yet `cudaErrorNotReady`, and thus the `DeviceAllocate()` (called in another thread) may consider that memory block to be free to be used for another CUDA stream in
https://github.com/NVlabs/cub/blob/c3cceac115c072fb63df1836ff46d8c60d9eb304/cub/util_allocator.cuh#L408-L409

This PR suggests to fix the race condition by recording the CUDA event while still holding the mutex in `DeviceFree()`.
