### PR TITLE
Add assignment operator to the TestBar test util class.

### DIFF
--- a/test/test_util.h
+++ b/test/test_util.h
@@ -1140,6 +1140,7 @@ struct NumericTraits<TestFoo>
 // Complex data type TestBar (with optimizations for fence-free warp-synchrony)
 //---------------------------------------------------------------------
 
+#define MAGIC 895245
 /**
  * TestBar complex data type
  */
@@ -1147,22 +1148,33 @@ struct TestBar
 {
     long long       x;
     int             y;
+    int             magic;
 
     // Constructor
-    __host__ __device__ __forceinline__ TestBar() : x(0), y(0)
+    __host__ __device__ __forceinline__ TestBar() : x(0), y(0), magic(MAGIC)
     {}
 
     // Constructor
-    __host__ __device__ __forceinline__ TestBar(int b) : x(b), y(b)
+    __host__ __device__ __forceinline__ TestBar(int b) : x(b), y(b), magic(MAGIC)
     {}
 
     // Constructor
-    __host__ __device__ __forceinline__ TestBar(long long x, int y) : x(x), y(y)
+    __host__ __device__ __forceinline__ TestBar(long long x, int y) : x(x), y(y), magic(MAGIC)
     {}
+
+    // Assignment operator
+    __host__ __device__ __forceinline__ TestBar& operator =(const TestBar& that)
+    {
+        assert (magic == MAGIC);
+        x = that.x;
+        y = that.y;
+        return *this;
+    }
 
     // Assignment from int operator
     __host__ __device__ __forceinline__ TestBar& operator =(int b)
     {
+        assert (magic == MAGIC);
         x = b;
         y = b;
         return *this;


### PR DESCRIPTION
n.b. this change to test code introduces a lot of failures in the CUB unit tests.
I'm not submitting those fixes -- I've done a few but not all of them. 

This change will identify all places in CUB code that attempts an assignment to uninitialized memory.
See https://github.com/NVlabs/cub/issues/184

Change:
I added a an assignment operator to the class, and I added a field
named `magic` that I set to certain value during
construction. Only an object that has been constructed is likely to
have that magic value properly set.

An assignment precondition is that the left-hand side is valid.
The assignment operators I added assert that the `magic` member of
the lhs has the correct value.