### PR TITLE
Removed unused code

### DIFF
--- a/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/device/dispatch/dispatch_scan.cuh
@@ -335,10 +335,6 @@ struct DispatchScan:
             int device_ordinal;
             if (CubDebug(error = cudaGetDevice(&device_ordinal))) break;
 
-            // Get SM count
-            int sm_count;
-            if (CubDebug(error = cudaDeviceGetAttribute (&sm_count, cudaDevAttrMultiProcessorCount, device_ordinal))) break;
-
             // Number of input tiles
             int tile_size = Policy::BLOCK_THREADS * Policy::ITEMS_PER_THREAD;
             int num_tiles = (num_items + tile_size - 1) / tile_size;


### PR DESCRIPTION
The only usage of `sm_count` was removed in https://github.com/NVlabs/cub/commit/ce261ed64b89be0748e302592e092363d8b08565#diff-6fa4d03743c49d2f079475e6d24387d8L462